### PR TITLE
Use parent's run method when running specs.

### DIFF
--- a/lib/parallel_split_test/core_ext/rspec_world.rb
+++ b/lib/parallel_split_test/core_ext/rspec_world.rb
@@ -1,0 +1,15 @@
+require 'parallel_split_test'
+require 'rspec/core/example'
+
+RSpec::Core::World.class_eval do
+  alias :example_count_without_parallel_split_test :example_count
+  def example_count(*args, &block)
+    count = example_count_without_parallel_split_test(*args, &block)
+    quotient = count / ParallelSplitTest.processes
+    if ParallelSplitTest.process_number < count % ParallelSplitTest.processes
+      quotient + 1
+    else
+      quotient
+    end
+  end
+end

--- a/spec/parallel_split_test_spec.rb
+++ b/spec/parallel_split_test_spec.rb
@@ -113,14 +113,15 @@ describe ParallelSplitTest do
           describe "Y" do
             #{(3...6).to_a.map{|i| "it{ puts 'it-ran-"+ i.to_s+"-in-'+ENV['TEST_ENV_NUMBER'].to_s + '-' }" }.join("\n")}
             describe "Y" do
-              #{(6...9).to_a.map{|i| "it{ puts 'it-ran-"+ i.to_s+"-in-'+ENV['TEST_ENV_NUMBER'].to_s + '-' }" }.join("\n")}
+              #{(6...11).to_a.map{|i| "it{ puts 'it-ran-"+ i.to_s+"-in-'+ENV['TEST_ENV_NUMBER'].to_s + '-' }" }.join("\n")}
             end
           end
         end
         RUBY
         result = parallel_split_test "xxx_spec.rb", :process_count => 3
-        expect(result.scan('3 examples, 0 failures').size).to eq(6)
-        expect(result.scan(/it-ran-.-in-.?-/).size).to eq(9)
+        expect(result.scan('4 examples, 0 failures').size).to eq(4)
+        expect(result.scan('3 examples, 0 failures').size).to eq(2)
+        expect(result.scan(/it-ran-\d+-in-(\d+)?-/).size).to eq(11)
       end
 
       it "runs faster" do


### PR DESCRIPTION
Originally I want to apply the [suite hooks](https://github.com/rspec/rspec-core/blob/fc767bef47807008899c24a8fd919236567c9023/lib/rspec/core/runner.rb#L113) to  `run_group_of_tests`. In order to do so, I think it's better to use the original `run` method than copying from the parent class because the implementation of the method can be  different in each version of RSpec.

In running the original `run` with this gem, `RSpec::Core::World#example_counts` has to return divided number with process size. So added a monkey patch (`core_ext/rspec_world.rb`).