### PR TITLE
Support close? of OutputRecorder

### DIFF
--- a/lib/parallel_split_test/output_recorder.rb
+++ b/lib/parallel_split_test/output_recorder.rb
@@ -7,7 +7,7 @@ module ParallelSplitTest
       @out = out
     end
 
-    %w[puts write print putc flush tty?].each do |method|
+    %w[puts write print putc flush tty? closed?].each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__
         def #{method}(*args)
           @recorded.#{method}(*args)


### PR DESCRIPTION
When using parallel_split_test with `--format progress`,
"undefined method 'closed?'" error occurs.